### PR TITLE
Add support for extracting tags from front matter

### DIFF
--- a/src/markers.ts
+++ b/src/markers.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from 'obsidian';
+import { App, TFile, getAllTags } from 'obsidian';
 import wildcard from 'wildcard';
 import * as leaflet from 'leaflet';
 import 'leaflet-extra-markers';
@@ -91,13 +91,11 @@ function checkTagPatternMatch(tagPattern: string, fileTags: string[]) {
 function getIconForMarker(marker: FileMarker, settings: PluginSettings, app: App) : leaflet.Icon {
 	let result = settings.markerIcons.default;
 	const fileCache = app.metadataCache.getFileCache(marker.file);
-	if (fileCache && fileCache.tags) {
-		const fileTags = fileCache.tags.map(tagCache => tagCache.tag);
-		// We iterate over the rules and apply them one by one, so later rules override earlier ones
-		for (const tag in settings.markerIcons) {
-			if (checkTagPatternMatch(tag, fileTags)) {
-				result = Object.assign({}, result, settings.markerIcons[tag]);
-			}
+	const fileTags = getAllTags(fileCache);
+	// We iterate over the rules and apply them one by one, so later rules override earlier ones
+	for (const tag in settings.markerIcons) {
+		if (checkTagPatternMatch(tag, fileTags)) {
+			result = Object.assign({}, result, settings.markerIcons[tag]);
 		}
 	}
 	return getIconFromOptions(result);


### PR DESCRIPTION
# Issues

- Closes #23.

# Summary

Previously, when determining the marker icon to use, only hashtags like "#dogs" were supported. Tags in the front matter in a note were ignored, for example:

```markdown
---
tags: [dogs]
---
```

This change adds support for tags in front matter, so that those tags can also be used to determine what marker icon to use.

# Testing

## Sequence

To test this, I used the default settings for __Edit the marker icons (advanced)__, and then created a note with the following content:

```markdown
---
tags: [dogs]
locations:
---

# AKC Museum of the Dog

🐶🐕🦮🐩🐕‍🦺🦴

## Location

- [📍](geo:40.750745500359905,-73.97787028645556)
 [101 Park Ave, New York, NY 10178](https://goo.gl/maps/EzG4hF5BxQYR5kp1A)
```

## Old Behaviour

After opening the map view, the marker is blue and uses the default circle icon.

## New Behaviour

After opening the map view, the marker uses a pawprint icon instead of the default circle icon.

<img width="1440" alt="Screen Shot 2021-09-24 at 1 27 12 AM" src="https://user-images.githubusercontent.com/13926659/134643925-665461cc-07e5-47a5-a15b-ae3583bd0d81.png">
