### PR TITLE
Shift filter box down to avoid covering pane title

### DIFF
--- a/src/mapView.ts
+++ b/src/mapView.ts
@@ -86,6 +86,7 @@ export class MapView extends ItemView {
 		}, (el: HTMLDivElement) => {
 			el.style.position = 'fixed';
 			el.style.zIndex = '2';
+			el.style.marginTop = '36px';
 		});
 		this.display.tagsBox = new TextComponent(controlsDiv);
 		this.display.tagsBox.setPlaceholder('Tags, e.g. "#one,#two"');


### PR DESCRIPTION
# Issues

*(None.)*

# Summary

The filter box currently covers the pane title, both on macOS and on Android.

This change adds top margin to the filter box so that it avoids covering the pane title. On Android, this also stops obscuring the menu button at the top-left for opening the left sidebar.

# Testing

## Sequence

To test this, I opened the Map View on macOS and Android.

I don't have an iPhone to test this with, or any other OSes ready currently.

## Old Behaviour

### macOS

The pane title is obscured.

<img width="1440" alt="Screen Shot 2021-09-30 at 11 27 12 PM" src="https://user-images.githubusercontent.com/13926659/135586003-c588c2b6-e48d-4212-aced-9e17487207a5.png">

### Android

Both the pane title and the menu button for opening the left sidebar are obscured.

<img width="240" alt="Screenshot_20210930-232814.png" src="https://user-images.githubusercontent.com/13926659/135588659-ece9ba3e-5e79-4ca4-b082-14021dec0376.png">

## New Behaviour

### macOS

The pane title is no longer obscured.

<img width="1440" alt="Screen Shot 2021-09-30 at 11 26 43 PM" src="https://user-images.githubusercontent.com/13926659/135587562-2246fba8-8a88-4924-b452-f35c9264b807.png">

### Android

Both the pane title and the menu button for opening the left sidebar are no longer obscured.

However, the filter box isn't quite lined up as well as it is on macOS — it would look more even if shifted downward a bit (higher margin value). (Open to any suggestions as to how to fix this to make it lined up for both macOS and Android, although this still should improve usability on Android a bit.)

<img width="240" alt="Screenshot_20210930-232954.png" src="https://user-images.githubusercontent.com/13926659/135588683-bd3607c8-933e-4ea0-a344-683628083958.png">
