### PR TITLE
Improved development build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w --environment BUILD:development",
+    "dev-dist": "rollup --config rollup.config.js -w",
     "build": "rollup --config rollup.config.js --environment BUILD:production"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An interactive map view for Obsidian.md",
   "main": "main.js",
   "scripts": {
-    "dev": "rollup --config rollup.config.js -w",
+    "dev": "rollup --config rollup.config.js -w --environment BUILD:development",
     "build": "rollup --config rollup.config.js --environment BUILD:production"
   },
   "keywords": [],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,7 @@ if you want to view the source visit the plugins github repository
 export default {
 	input: 'src/main.ts',
 	output: {
-		dir: './dist',
+		dir: process.env.BUILD === 'development' ? '.' : './dist',
 		sourcemap: isProd ? false : 'inline',
 		sourcemapExcludeSources: isProd,
 		format: 'cjs',
@@ -30,11 +30,13 @@ export default {
 		nodeResolve({browser: true}),
 		commonjs(),
 		postcss({ extensions: ['.css'], plugins: [postcss_url({url: 'inline'})] }),
-		copy({
-			targets: [
-				{ src: './manifest.json', dest: 'dist' },
-				{ src: './styles.css', dest: 'dist' }
-			]
-		})
+		...(process.env.BUILD !== 'development' ? [
+			copy({
+				targets: [
+					{ src: './manifest.json', dest: 'dist' },
+					{ src: './styles.css', dest: 'dist' }
+				]
+			})
+		] : []),
 	]
 };


### PR DESCRIPTION
The development build command used to build to the dist directory which made it difficult to develop.
The changes mean that the whole repository can be put in the obsidian plugins directory and built to the root directory where obsidian will look for it.