### PR TITLE
Improved regex parsing

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -341,8 +341,8 @@ export default class MapViewPlugin extends Plugin {
         let selectedLocation = null;
         if (match)
             selectedLocation = new leaflet.LatLng(
-                parseFloat(match[2]),
-                parseFloat(match[3])
+                parseFloat(match.groups.lat),
+                parseFloat(match.groups.long)
             );
         else {
             const fmLocation = getFrontMatterLocation(view.file, this.app);

--- a/src/main.ts
+++ b/src/main.ts
@@ -342,7 +342,7 @@ export default class MapViewPlugin extends Plugin {
         if (match)
             selectedLocation = new leaflet.LatLng(
                 parseFloat(match.groups.lat),
-                parseFloat(match.groups.long)
+                parseFloat(match.groups.lng)
             );
         else {
             const fmLocation = getFrontMatterLocation(view.file, this.app);

--- a/src/markers.ts
+++ b/src/markers.ts
@@ -209,10 +209,10 @@ export function verifyLocation(location: leaflet.LatLng) {
 export function matchInlineLocation(content: string): RegExpMatchArray[] {
     // Old syntax of ` `location: ... ` `. This syntax doesn't support a name so we leave an empty capture group
     const locationRegex1 =
-        /\`()location:\s*\[?([0-9.\-]+)\s*,\s*([0-9.\-]+)\]?\`/g;
+        /`location:\s*\[?(?<lat>[+-]?([0-9]*[.])?[0-9]+)\s*,\s*(?<long>[+-]?([0-9]*[.])?[0-9]+)]?`/g;
     // New syntax of `[name](geo:...)` and an optional tags as `tag:tagName` separated by whitespaces
     const locationRegex2 =
-        /\[(.*?)\]\(geo:([0-9.\-]+),([0-9.\-]+)\)[ \t]*((?:tag:[\w\/\-]+[\s\.]+)*)/g;
+        /\[(?<name>.*?)]\(geo:(?<lat>[+-]?([0-9]*[.])?[0-9]+),(?<long>[+-]?([0-9]*[.])?[0-9]+)\)[ \t]*(?<tags>(tag:[\w\/\-]+[\s.]+)*)/g;
     const matches1 = content.matchAll(locationRegex1);
     const matches2 = content.matchAll(locationRegex2);
     return Array.from(matches1).concat(Array.from(matches2));
@@ -235,18 +235,19 @@ async function getMarkersFromFileContent(
     for (const match of matches) {
         try {
             const location = new leaflet.LatLng(
-                parseFloat(match[2]),
-                parseFloat(match[3])
+                parseFloat(match.groups.lat),
+                parseFloat(match.groups.long)
             );
             verifyLocation(location);
             const marker = new FileMarker(file, location);
-            if (match[1] && match[1].length > 0) marker.extraName = match[1];
-            if (match[4]) {
+            if (match.groups.name && match.groups.name.length > 0)
+                marker.extraName = match.groups.name;
+            if (match.groups.tags) {
                 // Parse the list of tags
-                const tagRegex = /tag:([\w\/\-]+)/g;
-                const tags = match[4].matchAll(tagRegex);
+                const tagRegex = /tag:(?<tag>[\w\/\-]+)/g;
+                const tags = match.groups.tags.matchAll(tagRegex);
                 for (const tag of tags)
-                    if (tag[1]) marker.tags.push('#' + tag[1]);
+                    if (tag.groups.tag) marker.tags.push('#' + tag.groups.tag);
             }
             marker.fileLocation = match.index;
             marker.fileLine =
@@ -262,7 +263,7 @@ async function getMarkersFromFileContent(
             markers.push(marker);
         } catch (e) {
             console.log(
-                `Error converting location in file ${file.name}: could not parse ${match[1]} or ${match[2]}`,
+                `Error converting location in file ${file.name}: could not parse ${match[0]}`,
                 e
             );
         }

--- a/src/markers.ts
+++ b/src/markers.ts
@@ -209,10 +209,10 @@ export function verifyLocation(location: leaflet.LatLng) {
 export function matchInlineLocation(content: string): RegExpMatchArray[] {
     // Old syntax of ` `location: ... ` `. This syntax doesn't support a name so we leave an empty capture group
     const locationRegex1 =
-        /`location:\s*\[?(?<lat>[+-]?([0-9]*[.])?[0-9]+)\s*,\s*(?<long>[+-]?([0-9]*[.])?[0-9]+)]?`/g;
+        /`location:\s*\[?(?<lat>[+-]?([0-9]*[.])?[0-9]+)\s*,\s*(?<lng>[+-]?([0-9]*[.])?[0-9]+)]?`/g;
     // New syntax of `[name](geo:...)` and an optional tags as `tag:tagName` separated by whitespaces
     const locationRegex2 =
-        /\[(?<name>.*?)]\(geo:(?<lat>[+-]?([0-9]*[.])?[0-9]+),(?<long>[+-]?([0-9]*[.])?[0-9]+)\)[ \t]*(?<tags>(tag:[\w\/\-]+[\s.]+)*)/g;
+        /\[(?<name>.*?)]\(geo:(?<lat>[+-]?([0-9]*[.])?[0-9]+),(?<lng>[+-]?([0-9]*[.])?[0-9]+)\)[ \t]*(?<tags>(tag:[\w\/\-]+[\s.]+)*)/g;
     const matches1 = content.matchAll(locationRegex1);
     const matches2 = content.matchAll(locationRegex2);
     return Array.from(matches1).concat(Array.from(matches2));
@@ -236,7 +236,7 @@ async function getMarkersFromFileContent(
         try {
             const location = new leaflet.LatLng(
                 parseFloat(match.groups.lat),
-                parseFloat(match.groups.long)
+                parseFloat(match.groups.lng)
             );
             verifyLocation(location);
             const marker = new FileMarker(file, location);


### PR DESCRIPTION
The old regex relied on positional outputs which could get complex to maintain.
This changes the regex to use named capture groups.
This makes everything more explicit and easier to read.
Improves numerical captures to only capture valid numbers.