### PR TITLE
Added max tile zoom setting and increased the max zoom

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -18,3 +18,6 @@ export const HISTORY_SAVE_ZOOM_DIFF = 2;
 
 export const LAT_LIMITS = [-90, 90];
 export const LNG_LIMITS = [-180, 180];
+
+export const MAX_ZOOM = 25;
+export const DEFAULT_MAX_TILE_ZOOM = 19;

--- a/src/mapView.ts
+++ b/src/mapView.ts
@@ -41,6 +41,7 @@ import { LocationSuggest } from 'src/geosearch';
 import MapViewPlugin from 'src/main';
 import * as utils from 'src/utils';
 import { ViewControls } from 'src/viewControls';
+import { DEFAULT_MAX_TILE_ZOOM, MAX_ZOOM } from 'src/consts';
 
 export class MapView extends ItemView {
     private settings: PluginSettings;
@@ -248,11 +249,11 @@ export class MapView extends ItemView {
             }
             const neededClassName = revertMap ? 'dark-mode' : '';
             this.display.tileLayer = new leaflet.TileLayer(mapSourceUrl, {
-                maxZoom: 25,
+                maxZoom: MAX_ZOOM,
                 maxNativeZoom:
                     typeof chosenMapSource.maxZoom === 'number'
                         ? chosenMapSource.maxZoom
-                        : 19,
+                        : DEFAULT_MAX_TILE_ZOOM,
                 subdomains: ['mt0', 'mt1', 'mt2', 'mt3'],
                 attribution: attribution,
                 className: neededClassName,

--- a/src/mapView.ts
+++ b/src/mapView.ts
@@ -248,7 +248,11 @@ export class MapView extends ItemView {
             }
             const neededClassName = revertMap ? 'dark-mode' : '';
             this.display.tileLayer = new leaflet.TileLayer(mapSourceUrl, {
-                maxZoom: 20,
+                maxZoom: 25,
+                maxNativeZoom:
+                    typeof chosenMapSource.maxZoom === 'number'
+                        ? chosenMapSource.maxZoom
+                        : 19,
                 subdomains: ['mt0', 'mt1', 'mt2', 'mt3'],
                 attribution: attribution,
                 className: neededClassName,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -95,6 +95,7 @@ export type TileSource = {
     currentMode?: MapLightDark;
     preset?: boolean;
     ignoreErrors?: boolean;
+    maxZoom?: number;
 };
 
 export type OpenInSettings = {
@@ -200,6 +201,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
             name: 'CartoDB',
             urlLight:
                 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png',
+            maxZoom: 19,
             preset: true,
         },
     ],
@@ -228,7 +230,7 @@ export function convertLegacyMarkerIcons(settings: PluginSettings): boolean {
 export function convertLegacyTilesUrl(settings: PluginSettings): boolean {
     if (settings.tilesUrl) {
         settings.mapSources = [
-            { name: 'Default', urlLight: settings.tilesUrl },
+            { name: 'Default', urlLight: settings.tilesUrl, maxZoom: 19 },
         ];
         settings.tilesUrl = null;
         return true;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 import * as consts from 'src/consts';
 import { LatLng } from 'leaflet';
 import { SplitDirection } from 'obsidian';
+import { DEFAULT_MAX_TILE_ZOOM } from 'src/consts';
 
 export type PluginSettings = {
     defaultState: MapState;
@@ -201,7 +202,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
             name: 'CartoDB',
             urlLight:
                 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png',
-            maxZoom: 19,
+            maxZoom: DEFAULT_MAX_TILE_ZOOM,
             preset: true,
         },
     ],
@@ -230,7 +231,11 @@ export function convertLegacyMarkerIcons(settings: PluginSettings): boolean {
 export function convertLegacyTilesUrl(settings: PluginSettings): boolean {
     if (settings.tilesUrl) {
         settings.mapSources = [
-            { name: 'Default', urlLight: settings.tilesUrl, maxZoom: 19 },
+            {
+                name: 'Default',
+                urlLight: settings.tilesUrl,
+                maxZoom: DEFAULT_MAX_TILE_ZOOM,
+            },
         ];
         settings.tilesUrl = null;
         return true;

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -258,6 +258,7 @@ export class SettingsTab extends PluginSettingTab {
                 this.plugin.settings.mapSources.push({
                     name: '',
                     urlLight: '',
+                    maxZoom: 19,
                     currentMode: 'auto',
                 });
                 this.refreshMapSourceSettings(mapSourcesDiv);
@@ -392,6 +393,25 @@ export class SettingsTab extends PluginSettingTab {
                             setting.urlDark = value;
                             this.refreshPluginOnHide = true;
                             await this.plugin.saveSettings();
+                        });
+                })
+                .addText((component) => {
+                    component
+                        .setPlaceholder('Max Tile Zoom')
+                        .setValue(
+                            (typeof setting.maxZoom === 'number'
+                                ? setting.maxZoom
+                                : 19
+                            ).toString()
+                        )
+                        .onChange(async (value: string) => {
+                            let zoom = parseInt(value);
+                            if (typeof zoom == 'number') {
+                                zoom = Math.min(Math.max(0, zoom), 25);
+                                setting.maxZoom = zoom;
+                                this.refreshPluginOnHide = true;
+                                await this.plugin.saveSettings();
+                            }
                         });
                 });
             if (!setting.preset)

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -11,6 +11,7 @@ import { PluginSettings, DEFAULT_SETTINGS } from 'src/settings';
 import { getIconFromOptions, getIconFromRules } from 'src/markers';
 import { MapView } from 'src/mapView';
 import * as consts from 'src/consts';
+import { DEFAULT_MAX_TILE_ZOOM, MAX_ZOOM } from 'src/consts';
 
 export class SettingsTab extends PluginSettingTab {
     plugin: MapViewPlugin;
@@ -258,7 +259,7 @@ export class SettingsTab extends PluginSettingTab {
                 this.plugin.settings.mapSources.push({
                     name: '',
                     urlLight: '',
-                    maxZoom: 19,
+                    maxZoom: DEFAULT_MAX_TILE_ZOOM,
                     currentMode: 'auto',
                 });
                 this.refreshMapSourceSettings(mapSourcesDiv);
@@ -401,13 +402,13 @@ export class SettingsTab extends PluginSettingTab {
                         .setValue(
                             (typeof setting.maxZoom === 'number'
                                 ? setting.maxZoom
-                                : 19
+                                : DEFAULT_MAX_TILE_ZOOM
                             ).toString()
                         )
                         .onChange(async (value: string) => {
                             let zoom = parseInt(value);
                             if (typeof zoom == 'number') {
-                                zoom = Math.min(Math.max(0, zoom), 25);
+                                zoom = Math.min(Math.max(0, zoom), MAX_ZOOM);
                                 setting.maxZoom = zoom;
                                 this.refreshPluginOnHide = true;
                                 await this.plugin.saveSettings();


### PR DESCRIPTION
Added a configurable max tile zoom option to configure the maximum zoom level a tile server can handle.
This allows use of tile servers that have higher detail tiles available.

Increased the maximum map zoom so that the map can be zoomed in further.
If the map is zoomed in further than the tile server can handle it will max out at the configurable max tile zoom and just enlarge the highest resolution tile.

This fixes #38 