### PR TITLE
Fixed line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
     "tabWidth": 4,
-    "singleQuote": true
+    "singleQuote": true,
+    "endOfLine": "crlf"
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,4 @@
 {
     "tabWidth": 4,
-    "singleQuote": true,
-    "endOfLine": "crlf"
+    "singleQuote": true
 }


### PR DESCRIPTION
Default to `\r\n` line endings.
When running prettier it was generating changed files with no changes. This was due to incorrect line endings which github desktop was fixing.
The current encoding in the repository is `\r\n` so this just modifies the prettier config to match that.
Github desktop will now only show the files that have actually changed.

Also added a .gitattributes file which is related to line endings.