### PR TITLE
Added support to reposition pins

### DIFF
--- a/src/markers.ts
+++ b/src/markers.ts
@@ -18,6 +18,7 @@ export class FileMarker {
     file: TFile;
     /** In the case of an inline location, the position within the file where the location was found */
     fileLocation?: number;
+    fileLength?: number;
     /** In case of an inline location, the line within the file where the geolocation was found */
     fileLine?: number;
     location: leaflet.LatLng;
@@ -249,6 +250,7 @@ async function getMarkersFromFileContent(
                     if (tag[1]) marker.tags.push('#' + tag[1]);
             }
             marker.fileLocation = match.index;
+            marker.fileLength = match[0].length;
             marker.fileLine =
                 content.substring(0, marker.fileLocation).split('\n').length -
                 1;


### PR DESCRIPTION
This adds a context menu item to reposition pins.
When the context menu item is clicked the next click on the map will move the pin to that location.

You might want this implemented differently. It does not currently have any user feedback but it functionally works.

I still need to implement support for changing the front matter attribute.

Added an attribute to the FileMarker class to store the inline match length
Added a context menu item to the map pin to edit location which stores the pin attribute
When the map is clicked and the pin attribute is not null it will rewrite the pin location with the clicked location.
Implemented changing inline locations.

resolves #43 