### PR TITLE
Add polyfill for structured clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@popperjs/core": "^2.11.7",
         "boon-js": "^2.0.3",
+        "core-js": "^3.32.0",
         "fast-xml-parser": "^4.0.9",
         "leaflet": "~1.7.1",
         "leaflet-extra-markers": "github:coryasilva/Leaflet.ExtraMarkers",

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
     MarkdownPostProcessorContext,
     Notice,
 } from 'obsidian';
+import 'core-js/actual/structured-clone';
 import { ViewPlugin } from '@codemirror/view';
 import * as consts from 'src/consts';
 import * as leaflet from 'leaflet';


### PR DESCRIPTION
### What this does
- adds core-js library for polyfilling
- imports polyfill for structured clone

Structured clone seems to not be supported by certain webviews, adding a polyfill for it resolves problems on those devices. See more info here: #192 