### PR TITLE
Expand allowed filenames in queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@popperjs/core": "^2.11.7",
-        "boon-js": "^2.0.3",
+        "boon-js": "^2.0.5",
         "core-js": "^3.32.0",
         "fast-xml-parser": "^4.0.9",
         "leaflet": "~1.7.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -185,7 +185,7 @@ export default class MapViewPlugin extends Plugin {
                     // Allow templates in the embedded query, e.g. to automatically insert the file name
                     state.query = utils.formatEmbeddedWithTemplates(
                         state.query,
-                        ctx.sourcePath
+                        utils.escapeDoubleQuotes(ctx.sourcePath)
                     );
                     let map = new EmbeddedMap(
                         el,

--- a/src/query.ts
+++ b/src/query.ts
@@ -356,9 +356,10 @@ export class QuerySuggest extends PopoverSuggest<Suggestion> {
         const allPathNames = this.getAllPathNames(pathQuery);
         let toReturn: Suggestion[] = [{ text: 'PATHS', group: true }];
         for (const pathName of allPathNames) {
+            const escapedPathName = utils.escapeDoubleQuotes(pathName);
             toReturn.push({
                 text: pathName,
-                textToInsert: `${operator}:"${pathName}" `,
+                textToInsert: `${operator}:"${escapedPathName}" `,
                 insertAt: pathMatch.index,
                 insertSkip: pathMatch[0].length,
             });

--- a/src/regex.ts
+++ b/src/regex.ts
@@ -9,22 +9,17 @@ export const TAG_NAME_WITH_HEADER_AND_WILDCARD =
 export const INLINE_TAG_IN_NOTE = /tag:(?<tag>[\p{L}\p{N}_\/\-]+)/gu;
 export const PATH = "['p{L}p{N}_,&()/-\\.]+?";
 // path:"..."
-export const PATH_QUERY_WITH_HEADER =
-    /path:"(['\p{L}\p{N}_,&\(\)\s/\-\\\.]+?)"/gu;
-export const LINKEDTO_QUERY_WITH_HEADER =
-    /linkedto:"(['\p{L}\p{N}_,&\(\)\s/\-\\\.]+?)"/gu;
-export const LINKEDFROM_QUERY_WITH_HEADER =
-    /linkedfrom:"(['\p{L}\p{N}_,&\(\)\s/\-\\\.]+?)"/gu;
-// Known bug: this is not inclusive enough, many legal names with special characters would not be matched here
-export const NAME_QUERY_WITH_HEADER =
-    /name:"(['\p{L}\p{N}_,&\(\)\s/\-\\\.]+?)"/gu;
+export const PATH_QUERY_WITH_HEADER = /path:"((?:[^"]|\\")+?)"/gu;
+export const LINKEDTO_QUERY_WITH_HEADER = /linkedto:"((?:[^"]|\\")+?)"/gu;
+export const LINKEDFROM_QUERY_WITH_HEADER = /linkedfrom:"((?:[^"]|\\")+?)"/gu;
+export const NAME_QUERY_WITH_HEADER = /name:"((?:[^"]|\\")+?)"/gu;
 // path:"path with spaces" OR path:path_without_spaces
 export const QUOTED_OR_NOT_QUOTED_PATH =
-    /path:(("([\p{L}\p{N}_,&\(\)\s'/\-\\\.]*)")|([\p{L}\p{N}_,&\(\)'/\-\\\.]*))/gu;
+    /path:(("((?:[^"]|\\")*)")|((?:[^"\s]|\\")*))/gu;
 export const QUOTED_OR_NOT_QUOTED_LINKEDTO =
-    /linkedto:(("([\p{L}\p{N}_,&\(\)\s'/\-\\\.]*)")|([\p{L}\p{N}_,&\(\)'/\-\\\.]*))/gu;
+    /linkedto:(("((?:[^"]|\\")*)")|((?:[^"\s]|\\")*))/gu;
 export const QUOTED_OR_NOT_QUOTED_LINKEDFROM =
-    /linkedfrom:(("([\p{L}\p{N}_,&\(\)\s'/\-\\\.]*)")|([\p{L}\p{N}_,&\(\)'/\-\\\.]*))/gu;
+    /linkedfrom:(("((?:[^"]|\\")*)")|((?:[^"\s]|\\")*))/gu;
 export const COORDINATES =
     /(?<lat>[+-]?([0-9]*[.])?[0-9]+),(?<lng>[+-]?([0-9]*[.])?[0-9]+)/;
 export const INLINE_LOCATION_OLD_SYNTAX =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,6 +53,12 @@ export function formatEmbeddedWithTemplates(s: string, fileName: string) {
     return replaced;
 }
 
+export function escapeDoubleQuotes(s: string) {
+    const escapePattern = /"/g;
+    const replaced = s.replace(escapePattern, '\\$&');
+    return replaced;
+}
+
 type NewNoteType = 'singleLocation' | 'multiLocation';
 
 const CURSOR = '$CURSOR$';


### PR DESCRIPTION
**Fixes:**
- Adjust the regex of queries to include all filenames possible on different operating systems

I adjusted the regex for path queries by using an inverse character class `(?:[^"]|\\")`  instead of including possible characters. This would also allow emojis (resolving #189) and quotes for Linux and MacOS in file queries. Since the file already exists, we can assume that the filename is valid and can be queried. I've tested this patch for some time now and haven't noticed any problems.