### PR TITLE
Update README.md to match frontmatter syntax changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ First is a location tag in a note's [front matter](https://help.obsidian.md/Adva
 
 ```yaml
 ---
-location: '40.6892494, -74.0466891'
+location: "40.6892494,-74.0466891"
 ---
 ```
 


### PR DESCRIPTION
Front matter syntax after the new changes is: 

```
location: "12345,12345"
```

I have updated the README to match.