### PR TITLE
Fixed the "Cannot read properties of undefined (reading 'app')" error #253

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -782,6 +782,7 @@ export default class MapViewPlugin extends Plugin {
                 }
             }
             menus.addUrlConversionItems(
+                this.app,
                 menu,
                 editor,
                 view.file,

--- a/src/menus.ts
+++ b/src/menus.ts
@@ -141,6 +141,7 @@ export function addFocusNoteInMapView(
 }
 
 export function addUrlConversionItems(
+    app: App,
     menu: Menu,
     editor: Editor,
     file: TFile,
@@ -183,7 +184,7 @@ export function addUrlConversionItems(
                 clipboardLocation = await clipboardLocation;
             if (clipboardLocation)
                 utils.insertLocationToEditor(
-                    this.app,
+                    app,
                     clipboardLocation.location,
                     editor,
                     file,


### PR DESCRIPTION
Fixed the "Cannot read properties of undefined (reading 'app')" error to make "Paste as geolocation" work again #253