### PR TITLE
Allow for filtering by frontmatter properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,9 +613,9 @@ And while both plugins are about maps and use Leaflet.js as their visual engine,
 
 Many important bug fixes are waiting for me to have a little spare time, in the meantime had to settle for smaller release.
 
-- Fixed "Paste as geolocation" issue (https://github.com/esm7/obsidian-map-view/issues/253), thanks 
-@frees0l0!
-- Fixed "Using custom property instead default location does not work" (https://github.com/esm7/obsidian-map-view/issues/251).
+-   Fixed "Paste as geolocation" issue (https://github.com/esm7/obsidian-map-view/issues/253), thanks
+    @frees0l0!
+-   Fixed "Using custom property instead default location does not work" (https://github.com/esm7/obsidian-map-view/issues/251).
 
 ### 5.0.2
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -170,7 +170,8 @@ export class Query {
             let propertyValues: string[] = [];
             if (isExactName) {
                 const property = fileCache.frontmatter?.[propertyName];
-                if (typeof property === 'undefined') propertyValues = property;
+                if (typeof property !== 'undefined')
+                    propertyValues = [property];
             } else {
                 propertyValues = Object.keys(fileCache.frontmatter)
                     .filter((k) => k.includes(propertyName))


### PR DESCRIPTION
Support for `[property-name:property-value]` to query frontmatter. A quoted name or quoted value indicates an exact match on that name or value, and unquoted name/value does substring matching (this is how Obsidian handles it). Frontmatter property values are coerced to strings, so it's possible to match boolean and numerical properties. Date properties are already represented as strings in the file cache.


Fixes #257.