### PR TITLE
Allow overwrite of an empty location property

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,9 +615,9 @@ And while both plugins are about maps and use Leaflet.js as their visual engine,
 
 Many important bug fixes are waiting for me to have a little spare time, in the meantime had to settle for smaller release.
 
-- Fixed "Paste as geolocation" issue (https://github.com/esm7/obsidian-map-view/issues/253), thanks 
-@frees0l0!
-- Fixed "Using custom property instead default location does not work" (https://github.com/esm7/obsidian-map-view/issues/251).
+-   Fixed "Paste as geolocation" issue (https://github.com/esm7/obsidian-map-view/issues/253), thanks
+    @frees0l0!
+-   Fixed "Using custom property instead default location does not work" (https://github.com/esm7/obsidian-map-view/issues/251).
 
 ### 5.0.2
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -175,7 +175,11 @@ export async function verifyOrAddFrontMatter(
 ): Promise<boolean> {
     let locationAdded = false;
     await app.fileManager.processFrontMatter(file, (frontmatter: any) => {
-        if (fieldName in frontmatter && skipIfExists) {
+        if (
+            fieldName in frontmatter &&
+            frontmatter[fieldName] !== null &&
+            skipIfExists
+        ) {
             locationAdded = false;
             return;
         }


### PR DESCRIPTION
The "Add geolocation (front matter) to current note" action correctly avoids overwriting an existing location property. But I'm fussy about the order of properties in my location notes, so I prefer to apply a template with an empty location property in the right place. This change allows the action to overwrite an existing entry if it is null.