### PR TITLE
Don't attempt to parse null frontmatter locations

### DIFF
--- a/src/markers.ts
+++ b/src/markers.ts
@@ -420,6 +420,8 @@ export function getFrontMatterLocation(
     if (frontMatter && settings.frontMatterKey in frontMatter) {
         try {
             const frontMatterLocation = frontMatter[settings.frontMatterKey];
+            // Don't try to parse null locations.
+            if (frontMatterLocation === null) return null;
             // V1 format: an array in the format of `location: [lat,lng]`
             if (frontMatterLocation?.length == 2) {
                 // Allow arrays of either strings or numbers


### PR DESCRIPTION
Avoids cluttering up the dev console with logs like:

    Error converting location in file <path>:
        TypeError: Cannot read properties of null (reading 'match')`