### PR TITLE
Suggestion: Use high resolution map tiles by default

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -216,7 +216,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
         {
             name: 'CartoDB',
             urlLight:
-                'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png',
+                'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
             preset: true,
         },
     ],

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -216,7 +216,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
         {
             name: 'CartoDB',
             urlLight:
-                'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png',
+                'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png',
             preset: true,
         },
     ],


### PR DESCRIPTION
Hi, I just found this plugin and I love the idea behind it and the implementation!
I noticed that the map tiles were looking a little blurry. After a bit of research I found that you can add `@2x` to end of the CartoDB tile URL to get the "retina" resolution tiles.
I just changed it in my local settings and it works perfectly. Maybe this should be the default so you get better looking maps out of the box (with a high res display ofc). Don't know if it's feasable or necessary to make this dynamically react to the actual screen resolution.

If you disagree or chose not to make this the default intentionally, feel free to just close this PR.
Thanks.
