### PR TITLE
Fix auto theme not following Obsidian theme

### DIFF
--- a/src/baseMapView.ts
+++ b/src/baseMapView.ts
@@ -163,9 +163,14 @@ export abstract class BaseMapView extends ItemView {
     isDarkMode(settings: PluginSettings): boolean {
         if (settings.chosenMapMode === 'dark') return true;
         if (settings.chosenMapMode === 'light') return false;
+
         // Auto mode - check if the theme is dark
-        if ((this.app.vault as any).getConfig('theme') === 'obsidian')
-            return true;
+        const theme = (this.app.vault as any).getConfig('theme');
+        if (theme === 'obsidian') return true;
+        else if (theme === 'moonstone') return false;
+        else if (theme === 'system')
+            return !document.body.classList.contains('theme-light');
+
         return false;
     }
 

--- a/src/mapContainer.ts
+++ b/src/mapContainer.ts
@@ -220,9 +220,14 @@ export class MapContainer {
     isDarkMode(settings: PluginSettings): boolean {
         if (settings.chosenMapMode === 'dark') return true;
         if (settings.chosenMapMode === 'light') return false;
+
         // Auto mode - check if the theme is dark
-        if ((this.app.vault as any).getConfig('theme') === 'obsidian')
-            return true;
+        const theme = (this.app.vault as any).getConfig('theme');
+        if (theme === 'obsidian') return true;
+        else if (theme === 'moonstone') return false;
+        else if (theme === 'system')
+            return !document.body.classList.contains('theme-light');
+
         return false;
     }
 


### PR DESCRIPTION
When map view's theme is set to auto it will now follow Obsidian's theme.

Obsidian light (moonstone) -> light
Obsidian dark (obsidian) -> dark
Obsidian system -> system theme

Fixes #136
Fixes #274