### PR TITLE
Use Google Maps Place data in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!--ts-->
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: erez, at: Sun 03 Nov 2024 12:07:11 IST -->
+<!-- Added by: hal, at: Mon 16 Dec 21:49:38 GMT 2024 -->
 
 <!--te-->
 
@@ -235,12 +235,14 @@ This opens a dialog on which you can search (address or location based on your [
 When using Google Maps Places API, templates can extract additional result data.
 For instance, templates that match `google_maps_place_data.some.path` will be replaced with the value found at `some.path` in the [JSON serach result](https://developers.google.com/maps/documentation/places/web-service/place-data-fields).
 For instance, the following template would set a [place_id](https://developers.google.com/maps/documentation/places/web-service/place-id) property and tags the note with the [type](https://developers.google.com/maps/documentation/places/web-service/supported_types) of the place:
+
 ```
 ---
 place_id: "{{google_maps_place_data.place_id}}"
 ---
 #{{google_maps_place_data.types.0}}
 ```
+
 Currently only the Google Maps Places API supports this advanced templating feature.
 
 ![](img/new-note-popup.gif)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!--ts-->
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: hal, at: Mon 16 Dec 21:49:38 GMT 2024 -->
+<!-- Added by: hal, at: Mon 16 Dec 22:03:24 GMT 2024 -->
 
 <!--te-->
 
@@ -243,7 +243,7 @@ place_id: "{{google_maps_place_data.place_id}}"
 #{{google_maps_place_data.types.0}}
 ```
 
-Currently only the Google Maps Places API supports this advanced templating feature.
+Currently only Google Maps Places API supports this advanced templating feature.
 
 ![](img/new-note-popup.gif)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!--ts-->
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: hal, at: Sun 22 Dec 12:12:40 GMT 2024 -->
+<!-- Added by: hal, at: Sun 22 Dec 12:58:47 GMT 2024 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,17 @@ Map View adds an Obsidian command named "New geolocation note", which you can ma
 
 This opens a dialog on which you can search (address or location based on your [configured geocoding provider](#changing-a-geocoding-provider)) or paste a URL using the built-in or custom [URL parsing rules](#url-parsing-rules).
 
+When using Google Maps Places API, templates can extract additional result data.
+For instance, templates that match `google_maps_place_data.some.path` will be replaced with the value found at `some.path` in the [JSON serach result](https://developers.google.com/maps/documentation/places/web-service/place-data-fields).
+For instance, the following template would set a [place_id](https://developers.google.com/maps/documentation/places/web-service/place-id) property and tags the note with the [type](https://developers.google.com/maps/documentation/places/web-service/supported_types) of the place:
+```
+---
+place_id: "{{google_maps_place_data.place_id}}"
+---
+#{{google_maps_place_data.types.0}}
+```
+Currently only the Google Maps Places API supports this advanced templating feature.
+
 ![](img/new-note-popup.gif)
 
 ### In an Existing Note

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!--ts-->
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: hal, at: Mon 16 Dec 22:08:03 GMT 2024 -->
+<!-- Added by: hal, at: Sun 22 Dec 12:12:40 GMT 2024 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!--ts-->
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: hal, at: Mon 16 Dec 22:03:24 GMT 2024 -->
+<!-- Added by: hal, at: Mon 16 Dec 22:08:03 GMT 2024 -->
 
 <!--te-->
 
@@ -233,14 +233,14 @@ Map View adds an Obsidian command named "New geolocation note", which you can ma
 This opens a dialog on which you can search (address or location based on your [configured geocoding provider](#changing-a-geocoding-provider)) or paste a URL using the built-in or custom [URL parsing rules](#url-parsing-rules).
 
 When using Google Maps Places API, templates can extract additional result data.
-For instance, templates that match `google_maps_place_data.some.path` will be replaced with the value found at `some.path` in the [JSON serach result](https://developers.google.com/maps/documentation/places/web-service/place-data-fields).
+For instance, templates that match `googleMapsPlaceData.some.path` will be replaced with the value found at `some.path` in the [JSON serach result](https://developers.google.com/maps/documentation/places/web-service/place-data-fields).
 For instance, the following template would set a [place_id](https://developers.google.com/maps/documentation/places/web-service/place-id) property and tags the note with the [type](https://developers.google.com/maps/documentation/places/web-service/supported_types) of the place:
 
 ```
 ---
-place_id: "{{google_maps_place_data.place_id}}"
+place_id: "{{googleMapsPlaceData.place_id}}"
 ---
-#{{google_maps_place_data.types.0}}
+#{{googleMapsPlaceData.types.0}}
 ```
 
 Currently only Google Maps Places API supports this advanced templating feature.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-    "id": "obsidian-map-view-dev",
-    "name": "Map View dev",
+    "id": "obsidian-map-view",
+    "name": "Map View",
     "version": "5.0.3",
     "minAppVersion": "1.5.6",
     "description": "An interactive map view.",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-    "id": "obsidian-map-view",
-    "name": "Map View",
+    "id": "obsidian-map-view-dev",
+    "name": "Map View dev",
     "version": "5.0.3",
     "minAppVersion": "1.5.6",
     "description": "An interactive map view.",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/plugin-typescript": "^8.2.1",
         "@types/geojson": "^7946.0.7",
+        "@types/google.maps": "^3.58.1",
         "@types/leaflet": "^1.9.3",
         "@types/leaflet.markercluster": "^1.4.5",
         "@types/node": "^14.14.37",

--- a/src/geosearch.ts
+++ b/src/geosearch.ts
@@ -17,6 +17,7 @@ export class GeoSearchResult {
     location: leaflet.LatLng;
     resultType: 'searchResult' | 'url' | 'existingMarker';
     existingMarker?: FileMarker;
+    extraLocationData?: object;
 }
 
 export class GeoSearcher {
@@ -76,6 +77,7 @@ export class GeoSearcher {
                         name: result.name,
                         location: result.location,
                         resultType: 'searchResult',
+                        extraLocationData: result.extraLocationData
                     });
             } catch (e) {
                 console.log(
@@ -147,6 +149,7 @@ export async function googlePlacesSearch(
                     name: `${result?.name} (${result?.formatted_address})`,
                     location: geolocation,
                     resultType: 'searchResult',
+                    extraLocationData: {"google_maps_place": result},
                 } as GeoSearchResult);
             }
         }

--- a/src/geosearch.ts
+++ b/src/geosearch.ts
@@ -7,6 +7,7 @@ import { PluginSettings } from 'src/settings';
 import { UrlConvertor } from 'src/urlConvertor';
 import { FileMarker } from 'src/markers';
 import * as consts from 'src/consts';
+import * as utils from 'src/utils';
 
 /**
  * A generic result of a geosearch
@@ -17,7 +18,7 @@ export class GeoSearchResult {
     location: leaflet.LatLng;
     resultType: 'searchResult' | 'url' | 'existingMarker';
     existingMarker?: FileMarker;
-    extraLocationData?: object;
+    extraLocationData?: utils.ExtraLocationData;
 }
 
 export class GeoSearcher {
@@ -131,7 +132,7 @@ export async function googlePlacesSearch(
         'https://maps.googleapis.com/maps/api/place/textsearch/json?' +
         querystring.stringify(params);
     const googleContent = await request({ url: googleUrl });
-    const jsonContent = JSON.parse(googleContent) as any;
+    const jsonContent = JSON.parse(googleContent);
     let results: GeoSearchResult[] = [];
     if (
         jsonContent &&

--- a/src/geosearch.ts
+++ b/src/geosearch.ts
@@ -77,7 +77,7 @@ export class GeoSearcher {
                         name: result.name,
                         location: result.location,
                         resultType: 'searchResult',
-                        extraLocationData: result.extraLocationData
+                        extraLocationData: result.extraLocationData,
                     });
             } catch (e) {
                 console.log(
@@ -149,7 +149,7 @@ export async function googlePlacesSearch(
                     name: `${result?.name} (${result?.formatted_address})`,
                     location: geolocation,
                     resultType: 'searchResult',
-                    extraLocationData: {"google_maps_place": result},
+                    extraLocationData: { google_maps_place: result },
                 } as GeoSearchResult);
             }
         }

--- a/src/geosearch.ts
+++ b/src/geosearch.ts
@@ -149,7 +149,7 @@ export async function googlePlacesSearch(
                     name: `${result?.name} (${result?.formatted_address})`,
                     location: geolocation,
                     resultType: 'searchResult',
-                    extraLocationData: { google_maps_place_data: result },
+                    extraLocationData: { googleMapsPlaceData: result },
                 } as GeoSearchResult);
             }
         }

--- a/src/geosearch.ts
+++ b/src/geosearch.ts
@@ -149,7 +149,7 @@ export async function googlePlacesSearch(
                     name: `${result?.name} (${result?.formatted_address})`,
                     location: geolocation,
                     resultType: 'searchResult',
-                    extraLocationData: { google_maps_place: result },
+                    extraLocationData: { google_maps_place_data: result },
                 } as GeoSearchResult);
             }
         }

--- a/src/locationSearchDialog.ts
+++ b/src/locationSearchDialog.ts
@@ -143,7 +143,8 @@ export class LocationSearchDialog extends SuggestModal<SuggestInfo> {
             this.plugin.newFrontMatterNote(
                 value.location,
                 evt,
-                utils.sanitizePlaceNameForNoteName(value.name)
+                utils.sanitizePlaceNameForNoteName(value.name),
+                value.extraLocationData
             );
         else if (this.dialogAction == 'addToNote')
             this.addToNote(value.location, evt, value.name);

--- a/src/main.ts
+++ b/src/main.ts
@@ -118,7 +118,7 @@ export default class MapViewPlugin extends Plugin {
                                   )
                                 : null;
                         if (location) {
-                            this.newFrontMatterNote(location, null, label);
+                            this.newFrontMatterNote(location, null, label, {});
                         }
                     } else if (params.mvaction === 'addtocurrentnotefm') {
                         const location =
@@ -919,7 +919,8 @@ export default class MapViewPlugin extends Plugin {
     async newFrontMatterNote(
         location: leaflet.LatLng,
         ev: MouseEvent | KeyboardEvent | null,
-        query: string
+        query: string,
+        extraLocationData: object
     ) {
         const locationString = `${location.lat},${location.lng}`;
         const newFileName = utils.formatWithTemplates(
@@ -933,7 +934,8 @@ export default class MapViewPlugin extends Plugin {
             newFileName,
             locationString,
             this.settings.frontMatterKey,
-            this.settings.newNoteTemplate
+            this.settings.newNoteTemplate,
+            extraLocationData
         );
         // If there is an open map view, use it to decide how and where to open the file.
         // Otherwise, open the file from the active leaf

--- a/src/main.ts
+++ b/src/main.ts
@@ -920,7 +920,7 @@ export default class MapViewPlugin extends Plugin {
         location: leaflet.LatLng,
         ev: MouseEvent | KeyboardEvent | null,
         query: string,
-        extraLocationData: object
+        extraLocationData: utils.ExtraLocationData
     ) {
         const locationString = `${location.lat},${location.lng}`;
         const newFileName = utils.formatWithTemplates(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,9 @@ function resolveJsonPath(json: object, path: string): string {
     // Remove leading/trailing curly braces and split the path into parts
     const pathParts = path.replace(/[{}]/g, '').split('.');
     // Use reduce with optional chaining to traverse the path
-    return pathParts.reduce((current: object, part: string) => {return current?.[part];}, json);
+    return pathParts.reduce((current: object, part: string) => {
+        return current?.[part];
+    }, json);
 }
 
 function replaceJsonPaths(inputString: string, json: object) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,15 +51,17 @@ function resolveJsonPath(json: object, path: string): string {
     }, json);
 }
 
-function replaceJsonPaths(content: string, json: {[index: string]:any}) {
+function replaceJsonPaths(content: string, json: { [index: string]: any }) {
     // Use regex to find all patterns like {{some.path.to.data.0}}
 
     // Find patterns to replace that start with an attribute of json
     for (const [key, data] of Object.entries(json)) {
         const regex = new RegExp(`{{${key}\\.(.*?)}}`, 'g');
-        return content.replace(regex, (_, path: string) => {return resolveJsonPath(data, path);});
+        return content.replace(regex, (_, path: string) => {
+            return resolveJsonPath(data, path);
+        });
     }
-    return content
+    return content;
 }
 
 export function formatWithTemplates(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,40 +42,15 @@ export function getLastUsedValidMarkdownLeaf() {
 }
 
 function resolveJsonPath(json: object, path: string): string {
+    // convert a string path like "some.path.to.data.0" to the value at that path in json
     // Remove leading/trailing curly braces and split the path into parts
     const pathParts = path.replace(/[{}]/g, '').split('.');
-
-    // Iterate through each part of the path
-    let current = json;
-    for (let part of pathParts) {
-        // Handle array index
-        const arrayMatch = part.match(/^(\w+)\[(\d+)\]$/);
-        if (arrayMatch) {
-            const key = arrayMatch[1];
-            const index = parseInt(arrayMatch[2], 10);
-            if (
-                current[key] &&
-                Array.isArray(current[key]) &&
-                current[key][index] !== undefined
-            ) {
-                current = current[key][index];
-            } else {
-                return ''; // Path doesn't exist
-            }
-        } else {
-            // Access object property
-            if (current && current.hasOwnProperty(part)) {
-                current = current[part];
-            } else {
-                return ''; // Path doesn't exist
-            }
-        }
-    }
-    return JSON.stringify(current);
+    // Use reduce with optional chaining to traverse the path
+    return pathParts.reduce((current: object, part: string) => {return current?.[part];}, json);
 }
 
 function replaceJsonPaths(inputString: string, json: object) {
-    // Use regex to find all patterns like {{some.path.to[0].data}}
+    // Use regex to find all patterns like {{some.path.to.data.0}}
     return inputString.replace(/{{(.*?)}}/g, (_, path: string) => {
         const value = resolveJsonPath(json, path);
         // return value !== undefined ? value : null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,7 @@ export function getLastUsedValidMarkdownLeaf() {
     return null;
 }
 
-function resolveJsonPath(json: object, path: string) : string {
+function resolveJsonPath(json: object, path: string): string {
     // Remove leading/trailing curly braces and split the path into parts
     const pathParts = path.replace(/[{}]/g, '').split('.');
 
@@ -53,17 +53,21 @@ function resolveJsonPath(json: object, path: string) : string {
         if (arrayMatch) {
             const key = arrayMatch[1];
             const index = parseInt(arrayMatch[2], 10);
-            if (current[key] && Array.isArray(current[key]) && current[key][index] !== undefined) {
+            if (
+                current[key] &&
+                Array.isArray(current[key]) &&
+                current[key][index] !== undefined
+            ) {
                 current = current[key][index];
             } else {
-                return ""; // Path doesn't exist
+                return ''; // Path doesn't exist
             }
         } else {
             // Access object property
             if (current && current.hasOwnProperty(part)) {
                 current = current[part];
             } else {
-                return ""; // Path doesn't exist
+                return ''; // Path doesn't exist
             }
         }
     }
@@ -79,7 +83,11 @@ function replaceJsonPaths(inputString: string, json: object) {
     });
 }
 
-export function formatWithTemplates(s: string, query = '', extraLocationData={}) {
+export function formatWithTemplates(
+    s: string,
+    query = '',
+    extraLocationData = {}
+) {
     const datePattern = /{{date:([a-zA-Z\-\/\.\:]*)}}/g;
     const queryPattern = /{{query}}/g;
     let replaced = s
@@ -88,8 +96,8 @@ export function formatWithTemplates(s: string, query = '', extraLocationData={})
             return moment().format(pattern);
         })
         .replace(queryPattern, query);
-    
-    replaced = replaceJsonPaths(replaced, extraLocationData)
+
+    replaced = replaceJsonPaths(replaced, extraLocationData);
 
     return replaced;
 }
@@ -142,16 +150,20 @@ export async function newNote(
     location: string,
     frontMatterKey: string,
     templatePath: string,
-    extraLocationData?: object,
+    extraLocationData?: object
 ): Promise<[TFile, number]> {
     let templateContent = '';
     if (templatePath && templatePath.length > 0)
         templateContent = await app.vault.adapter.read(templatePath);
-    console.log("extraLocationData:");
+    console.log('extraLocationData:');
     console.log(extraLocationData);
 
-    templateContent = formatWithTemplates(templateContent, "", extraLocationData);
-    
+    templateContent = formatWithTemplates(
+        templateContent,
+        '',
+        extraLocationData
+    );
+
     const templateFrontMatterInfo = getFrontMatterInfo(templateContent);
 
     let newFrontMatterContents;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,13 +51,15 @@ function resolveJsonPath(json: object, path: string): string {
     }, json);
 }
 
-function replaceJsonPaths(inputString: string, json: object) {
+function replaceJsonPaths(content: string, json: {[index: string]:any}) {
     // Use regex to find all patterns like {{some.path.to.data.0}}
-    return inputString.replace(/{{(.*?)}}/g, (_, path: string) => {
-        const value = resolveJsonPath(json, path);
-        // return value !== undefined ? value : null;
-        return value;
-    });
+
+    // Find patterns to replace that start with an attribute of json
+    for (const [key, data] of Object.entries(json)) {
+        const regex = new RegExp(`{{${key}\\.(.*?)}}`, 'g');
+        return content.replace(regex, (_, path: string) => {return resolveJsonPath(data, path);});
+    }
+    return content
 }
 
 export function formatWithTemplates(
@@ -132,8 +134,6 @@ export async function newNote(
     let templateContent = '';
     if (templatePath && templatePath.length > 0)
         templateContent = await app.vault.adapter.read(templatePath);
-    console.log('extraLocationData:');
-    console.log(extraLocationData);
 
     templateContent = formatWithTemplates(
         templateContent,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,6 @@ export function getLastUsedValidMarkdownLeaf() {
     return null;
 }
 
-
 function resolveJsonPath(json: object, path: string): string | undefined {
     // Convert a string path like "some.path.to.data.0" to the value at that path in JSON
     // Remove leading/trailing curly braces and split the path into parts
@@ -52,7 +51,7 @@ function resolveJsonPath(json: object, path: string): string | undefined {
 
 export type ExtraLocationData = {
     googleMapsPlaceData?: google.maps.places.PlaceResult;
-}
+};
 
 function replaceJsonPaths(content: string, json: ExtraLocationData) {
     // Use regex to find all patterns like {{some.path.to.data.0}}
@@ -62,7 +61,7 @@ function replaceJsonPaths(content: string, json: ExtraLocationData) {
         const regex = new RegExp(`{{${key}\\.(.*?)}}`, 'g');
         return content.replace(regex, (_, path: string) => {
             const result = resolveJsonPath(data, path);
-            return result ? result : "";
+            return result ? result : '';
         });
     }
     return content;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export function getLastUsedValidMarkdownLeaf() {
 }
 
 function resolveJsonPath(json: object, path: string): string {
-    // convert a string path like "some.path.to.data.0" to the value at that path in json
+    // Convert a string path like "some.path.to.data.0" to the value at that path in JSON
     // Remove leading/trailing curly braces and split the path into parts
     const pathParts = path.replace(/[{}]/g, '').split('.');
     // Use reduce with optional chaining to traverse the path
@@ -155,7 +155,6 @@ export async function newNote(
         newFrontMatterContents = 'locations:';
         contentsBody = `[${CURSOR}](geo:${location})\n`;
     }
-
     let content = `---\n${newFrontMatterContents}\n${
         templateFrontMatterInfo.frontmatter
     }---\n\n${contentsBody}${templateContent.substring(


### PR DESCRIPTION
I really like this plugin and I've been using Templater to query the Google Maps Place API and automatically fill in details like:
- the type of place (`restaurant`, `cafe`, etc ...)
- the rating
- the `place_id` so I can build a direction URL and a search URL (https://developers.google.com/maps/documentation/urls/get-started)
- the more human friendly `name` attribute.
- address

Same issue as https://github.com/esm7/obsidian-map-view/issues/173

### Solution
A template can contain paths to data returned in the full [Google Maps places data](https://developers.google.com/maps/documentation/places/web-service/place-data-fields)
It would be easy to extend the solution to OSM.

#### Example
With this template:
```
---
gmaps_place_id: "{{googleMapsPlaceData.place_id}}"
address: "{{googleMapsPlaceData.formatted_address}}"
rating: "{{googleMapsPlaceData.rating}}"
---
#{{googleMapsPlaceData.types.0}}
main type of place: {{googleMapsPlaceData.types.0}}
all types: {{googleMapsPlaceData.types}}
opening_hours: {{googleMapsPlaceData.opening_hours.open_now}}
address: {{googleMapsPlaceData.formatted_address}}

test: {{googleMapsPlaceData.types.99}}
test: {{googleMapsPlaceData.types.99.asdasd}}
test: {{googleMapsPlaceData.opening_hours.open_non_existant_key}}
test: {{googleMapsPlaceData.opening_hours.open_non_existant_key.asdasd}}
```
A query to Katz's Delicatessen results in this note:
![image](https://github.com/user-attachments/assets/ee25c37a-3d03-4c59-983f-fc2f0a327a94)

Undefined paths return the empty string.


<details>
<summary>Updating current notes without `place_id`</summary>
I'm using Templater to update my old geo tagged places that don't have this extra information. In my startup template I have:

```
templaterPlugin.registerEvent(tp.app.workspace.on('file-open', async (file) => {

    let needs_gmaps_place_id = false;
    let encodedCoords;
    await tp.app.fileManager.processFrontMatter(file, (frontmatter) => {
        needs_gmaps_place_id = ("location" in frontmatter) && !(("gmaps_place_id" in frontmatter));
        if (needs_gmaps_place_id) {
            encodedCoords = encodeURIComponent(frontmatter["location"]);
        }
    });

    if (needs_gmaps_place_id) {
        // Set gmap_place_id if we dont have it set:
        const googleMapsPlacesUrl = `https://maps.googleapis.com/maps/api/geocode/json?latlng=${encodedCoords}&key=[MY API KEY HERE]`
        const googleMapsJsonPlaceId = await tp.web.request(googleMapsPlacesUrl, "results.0.place_id");
        if (googleMapsJsonPlaceId && (googleMapsJsonPlaceId.length > 0)) {
            await tp.app.fileManager.processFrontMatter(file, (frontmatter) => {
                frontmatter["gmaps_place_id"] = googleMapsJsonPlaceId;
            });
        }
    }

    await tp.app.fileManager.processFrontMatter(file, (frontmatter) => {
        if ("location" in frontmatter) {
            const encodedCoords = encodeURIComponent(frontmatter["location"]);

            frontmatter["directions"] = "https://www.google.com/maps/dir/?api=1&destination=" + encodedCoords;
            frontmatter["location_link"] = "https://www.google.com/maps/search/?api=1&query=" + encodedCoords;
            if ("gmaps_place_id" in frontmatter) {
                // We can improve the search!
                const encodedPlaceId = encodeURIComponent(frontmatter["gmaps_place_id"]);
                // frontmatter["directions"] = `${frontmatter["directions"]}&destination_place_id=${encodedPlaceId}`;
                // if you use the coords, google maps doesnt show the name of the place when looking for directions
                frontmatter["directions"] = `https://www.google.com/maps/dir/?api=1&destination=null&destination_place_id=${encodedPlaceId}`;
                frontmatter["location_link"] = `${frontmatter["location_link"]}&query_place_id=${encodedPlaceId}`;
            }
        }
    });
}))
```

</details>

