### PR TITLE
Fixes #308 (missing context menu items) add nullish coalescer in case getLocationOnEditorLine() returns null

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -856,12 +856,13 @@ export default class MapViewPlugin extends Plugin {
             }
             if (!multiLineMode) {
                 const editorLine = editor.getCursor().line;
-                const [location, name] = this.getLocationOnEditorLine(
-                    editor,
-                    editorLine,
-                    view,
-                    true,
-                );
+                const [location, name] =
+                    this.getLocationOnEditorLine(
+                        editor,
+                        editorLine,
+                        view,
+                        true,
+                    ) ?? [];
                 if (location) {
                     const editorLine = editor.getCursor().line;
                     menus.addShowOnMap(


### PR DESCRIPTION
This is a fix for #308 

The only change is to `main.ts:859`:

```ts
                const [location, name] = this.getLocationOnEditorLine(
                    editor,
                    editorLine,
                    view,
                    true,
                ) ?? [];
```

I just added nullish coalescer in case `getLocationOnEditorLine()` returns null.

Context menu items should now render fine.