### PR TITLE
Migrate API keys to the new Secret Storage API

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,6 +170,7 @@ export function registerCliHandlers(
                     'graphhopper',
                     { profile: params.profile },
                     settings,
+                    app,
                 );
                 return [
                     `Profile: ${result.profileUsed}`,

--- a/src/geosearch.ts
+++ b/src/geosearch.ts
@@ -45,8 +45,11 @@ export class GeoSearcher {
                 },
             });
         } else if (settings.searchProvider == 'google') {
+            //TODO: this can be improved so that it auto-updates when `apiKey` is changed
             this.searchProvider = new geosearch.GoogleProvider({
-                apiKey: settings.geocodingApiKeySecret,
+                apiKey: app.secretStorage.getSecret(
+                    settings.geocodingApiKeySecret,
+                ),
             });
         }
     }
@@ -129,10 +132,13 @@ export async function googlePlacesSearch(
     query: string,
     settings: PluginSettings,
     centerOfSearch: leaflet.LatLng | null,
+    app: App,
 ): Promise<GeoSearchResult[]> {
     if (settings.searchProvider != 'google' || !settings.useGooglePlacesNew2025)
         return [];
-    const googleApiKey = settings.geocodingApiKeySecret;
+    const googleApiKey = app.secretStorage.getSecret(
+        settings.geocodingApiKeySecret,
+    );
 
     // Request body for the new Places API
     const requestBody = {

--- a/src/geosearch.ts
+++ b/src/geosearch.ts
@@ -46,7 +46,7 @@ export class GeoSearcher {
             });
         } else if (settings.searchProvider == 'google') {
             this.searchProvider = new geosearch.GoogleProvider({
-                apiKey: settings.geocodingApiKey,
+                apiKey: settings.geocodingApiKeySecret,
             });
         }
     }
@@ -76,7 +76,7 @@ export class GeoSearcher {
         if (
             this.settings.searchProvider == 'google' &&
             this.settings.useGooglePlacesNew2025 &&
-            this.settings.geocodingApiKey
+            this.settings.geocodingApiKeySecret
         ) {
             try {
                 const placesResults = await googlePlacesSearch(
@@ -132,7 +132,7 @@ export async function googlePlacesSearch(
 ): Promise<GeoSearchResult[]> {
     if (settings.searchProvider != 'google' || !settings.useGooglePlacesNew2025)
         return [];
-    const googleApiKey = settings.geocodingApiKey;
+    const googleApiKey = settings.geocodingApiKeySecret;
 
     // Request body for the new Places API
     const requestBody = {

--- a/src/geosearch.ts
+++ b/src/geosearch.ts
@@ -27,10 +27,13 @@ export class GeoSearcher {
         | geosearch.GoogleProvider = null;
     private settings: PluginSettings;
     private urlConvertor: UrlConvertor;
+    private app: App;
 
     constructor(app: App, settings: PluginSettings) {
         this.settings = settings;
         this.urlConvertor = new UrlConvertor(app, settings);
+        this.app = app;
+
         if (settings.searchProvider == 'osm') {
             if (!settings.osmUser) {
                 new Notice(
@@ -86,6 +89,9 @@ export class GeoSearcher {
                     query,
                     this.settings,
                     searchArea?.getCenter(),
+                    this.app.secretStorage.getSecret(
+                        this.settings.geocodingApiKeySecret,
+                    ),
                 );
                 for (const result of placesResults) {
                     results.push({
@@ -132,13 +138,10 @@ export async function googlePlacesSearch(
     query: string,
     settings: PluginSettings,
     centerOfSearch: leaflet.LatLng | null,
-    app: App,
+    googleApiKey: string,
 ): Promise<GeoSearchResult[]> {
     if (settings.searchProvider != 'google' || !settings.useGooglePlacesNew2025)
         return [];
-    const googleApiKey = app.secretStorage.getSecret(
-        settings.geocodingApiKeySecret,
-    );
 
     // Request body for the new Places API
     const requestBody = {

--- a/src/mapContainer.ts
+++ b/src/mapContainer.ts
@@ -1832,6 +1832,7 @@ export class MapContainer {
                                     marker.location,
                                     menu,
                                     this.settings,
+                                    this.app,
                                 );
                                 menu.showAtMouseEvent(ev.originalEvent);
                             }

--- a/src/menus.ts
+++ b/src/menus.ts
@@ -507,6 +507,7 @@ export function populateRouting(
                     geolocation,
                     submenu,
                     settings,
+                    app,
                 );
             });
         }
@@ -538,6 +539,7 @@ export function populateRouting(
                                 geolocation,
                                 menu,
                                 settings,
+                                app,
                             );
                             menu.showAtMouseEvent(originalEvent);
                         }
@@ -553,6 +555,7 @@ export function populateRouteToPoint(
     geolocation: leaflet.LatLng,
     menu: Menu,
     settings: settings.PluginSettings,
+    app: App,
 ) {
     // The first priority is to choose the user-selected routing source.
     // If there isn't any, we try the real-time (GPS) location.
@@ -586,6 +589,7 @@ export function populateRouteToPoint(
                     { profile: cleanedProfile },
                     mapContainer,
                     settings,
+                    app,
                 );
             });
         });

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -48,7 +48,7 @@ export async function calcRoute(
         ...settings.routingGraphHopperExtra,
     };
     const resultContent: any = await request({
-        url: `https://graphhopper.com/api/1/route?key=${settings.routingGraphHopperApiKeySecret}`,
+        url: `https://graphhopper.com/api/1/route?key=${apiKey}`,
         method: 'POST',
         body: JSON.stringify(requestBody),
         headers: {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -2,7 +2,7 @@ import { MapContainer } from 'src/mapContainer';
 import MapViewPlugin from 'src/main';
 import { type PluginSettings } from 'src/settings';
 import * as leaflet from 'leaflet';
-import { request, Notice } from 'obsidian';
+import { request, Notice, App } from 'obsidian';
 import { type GeoJSON } from 'geojson';
 
 type RoutingProvider = 'graphhopper';
@@ -26,8 +26,12 @@ export async function calcRoute(
     provider: RoutingProvider,
     params: RoutingParams,
     settings: PluginSettings,
+    app: App,
 ): Promise<RoutingResult> {
-    if (!settings.routingGraphHopperApiKey) {
+    const apiKey = app.secretStorage.getSecret(
+        settings.routingGraphHopperApiKeySecret,
+    );
+    if (!apiKey) {
         throw new Error(
             'No GraphHopper API key configured in Map View settings.',
         );
@@ -44,7 +48,7 @@ export async function calcRoute(
         ...settings.routingGraphHopperExtra,
     };
     const resultContent: any = await request({
-        url: `https://graphhopper.com/api/1/route?key=${settings.routingGraphHopperApiKey}`,
+        url: `https://graphhopper.com/api/1/route?key=${settings.routingGraphHopperApiKeySecret}`,
         method: 'POST',
         body: JSON.stringify(requestBody),
         headers: {
@@ -78,8 +82,9 @@ export async function doRouting(
     params: RoutingParams,
     map: MapContainer,
     settings: PluginSettings,
+    app: App,
 ) {
-    if (!settings.routingGraphHopperApiKey) {
+    if (!settings.routingGraphHopperApiKeySecret) {
         new Notice(
             'You must first provide a GraphHopper API key in the settings.',
         );
@@ -92,6 +97,7 @@ export async function doRouting(
             provider,
             params,
             settings,
+            app,
         );
         map.addFloatingRoute(routingResult);
     } catch (e) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -643,7 +643,7 @@ export async function convertLegacySettings(
     if (convertLegacyAPIKeysToSecretStorage(settings, plugin.app)) {
         changed = true;
         new Notice(
-            'Map View: Legacy API keys for Geocoding and/or converted to the new Secret Storage API.',
+            'Map View: Legacy API keys for Geocoding and/or converted to the new Secret Storage API. You may need to re-link the secret in settings afterwards.',
         );
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import { LatLng, type PathOptions } from 'leaflet';
-import { type SplitDirection, Notice } from 'obsidian';
+import { type SplitDirection, App, Notice } from 'obsidian';
 import { type MapState, type LegacyMapState, mergeStates } from 'src/mapState';
 import type MapViewPlugin from 'src/main';
 import * as consts from 'src/consts';
@@ -52,7 +52,11 @@ export type PluginSettings = {
     searchProvider: 'osm' | 'google';
     osmUser: string;
     searchDelayMs: number;
+    /**
+     * @deprecated - Use "geocodingApiKeySecret"
+     */
     geocodingApiKey: string;
+    geocodingApiKeySecret: string;
     useGooglePlacesNew2025: boolean;
     googlePlacesDataFields: string;
     saveHistory: boolean;
@@ -72,7 +76,11 @@ export type PluginSettings = {
     zoomOnGeolinkPreview: number;
     handleGeolinkContextMenu: boolean;
     routingUrl: string;
+    /**
+     * @deprecated - use "routingGraphHopperApiKeySecret"
+     */
     routingGraphHopperApiKey: string;
+    routingGraphHopperApiKeySecret: string;
     routingGraphHopperProfiles: string;
     routingGraphHopperExtra: any;
     cacheAllTiles: boolean;
@@ -92,6 +100,8 @@ export type DepracatedFields = {
     defaultTags?: string[];
     snippetLines?: number;
     useGooglePlaces?: boolean;
+    routingGraphHopperApiKey: string;
+    geocodingApiKey: string;
 };
 
 export type MapLightDark = 'auto' | 'light' | 'dark';
@@ -285,6 +295,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
     osmUser: '',
     searchDelayMs: 250,
     geocodingApiKey: '',
+    geocodingApiKeySecret: '',
     useGooglePlacesNew2025: false,
     googlePlacesDataFields: '',
     mapSources: [
@@ -317,6 +328,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
     routingUrl:
         'https://www.google.com/maps/dir/?api=1&origin={x0},{y0}&destination={x1},{y1}',
     routingGraphHopperApiKey: '',
+    routingGraphHopperApiKeySecret: '',
     routingGraphHopperProfiles: 'foot, bike, car',
     routingGraphHopperExtra: {},
     cacheAllTiles: true,
@@ -484,6 +496,30 @@ export function convertLegacyGooglePlaces(settings: PluginSettings): boolean {
     return changed;
 }
 
+export function convertLegacyAPIKeysToSecretStorage(
+    settings: PluginSettings & DepracatedFields,
+    app: App,
+): boolean {
+    let changed = false;
+    if (settings.geocodingApiKey) {
+        app.secretStorage.setSecret(
+            settings.geocodingApiKeySecret,
+            settings.geocodingApiKey,
+        );
+        delete settings.geocodingApiKey;
+        changed = true;
+    }
+    if (settings.routingGraphHopperApiKey) {
+        app.secretStorage.setSecret(
+            settings.routingGraphHopperApiKeySecret,
+            settings.routingGraphHopperApiKey,
+        );
+        delete settings.routingGraphHopperApiKey;
+        changed = true;
+    }
+    return changed;
+}
+
 export function convertMarkerIconRulesToDisplayRules(
     settings: PluginSettings & DepracatedFields,
 ) {
@@ -603,6 +639,13 @@ export async function convertLegacySettings(
         changed = true;
         new Notice(
             'Map View: legacy marker icon rules were converted to the new "display rules" format.',
+        );
+    }
+
+    if (convertLegacyAPIKeysToSecretStorage(settings, this.app)) {
+        changed = true;
+        new Notice(
+            'Map View: Legacy API keys for Geocoding and/or converted to the new Secret Storage API.',
         );
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -502,18 +502,16 @@ export function convertLegacyAPIKeysToSecretStorage(
 ): boolean {
     let changed = false;
     if (settings.geocodingApiKey) {
-        app.secretStorage.setSecret(
-            settings.geocodingApiKeySecret,
-            settings.geocodingApiKey,
-        );
+        const key = 'obsidian-map-view-geocoding-apikey';
+        app.secretStorage.setSecret(key, settings.geocodingApiKey);
+        settings.geocodingApiKeySecret = key;
         delete settings.geocodingApiKey;
         changed = true;
     }
     if (settings.routingGraphHopperApiKey) {
-        app.secretStorage.setSecret(
-            settings.routingGraphHopperApiKeySecret,
-            settings.routingGraphHopperApiKey,
-        );
+        const key = 'obsidian-map-view-routing-graphhopper-apikey';
+        app.secretStorage.setSecret(key, settings.routingGraphHopperApiKey);
+        settings.geocodingApiKeySecret = key;
         delete settings.routingGraphHopperApiKey;
         changed = true;
     }
@@ -642,7 +640,7 @@ export async function convertLegacySettings(
         );
     }
 
-    if (convertLegacyAPIKeysToSecretStorage(settings, this.app)) {
+    if (convertLegacyAPIKeysToSecretStorage(settings, plugin.app)) {
         changed = true;
         new Notice(
             'Map View: Legacy API keys for Geocoding and/or converted to the new Secret Storage API.',

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -5,6 +5,8 @@ import {
     TextAreaComponent,
     Setting,
     DropdownComponent,
+    SecretComponent,
+    Component,
 } from 'obsidian';
 
 import MapViewPlugin from 'src/main';
@@ -23,6 +25,8 @@ import { DEFAULT_MAX_TILE_ZOOM, MAX_ZOOM } from 'src/consts';
 import { openManagerDialog } from 'src/offlineTiles.svelte';
 import { SvelteModal } from 'src/svelte';
 import DisplayRules from './components/DisplayRules.svelte';
+import { value } from 'happy-dom/lib/PropertySymbol';
+import { V } from 'vitest/dist/chunks/reporters.d.DVUYHHhe';
 
 export class SettingsTab extends PluginSettingTab {
     plugin: MapViewPlugin;
@@ -142,21 +146,15 @@ export class SettingsTab extends PluginSettingTab {
             .setDesc(
                 'If using Google as the geocoding search provider, paste the API key here. See the plugin documentation for more details. Changes are applied after restart.',
             )
-            .addText((component) => {
-                component
-                    .setValue(this.plugin.settings.geocodingApiKey)
-                    .onChange(async (value) => {
-                        this.plugin.settings.geocodingApiKey = value;
-                        await this.plugin.saveSettings();
-                        component.inputEl.style.borderColor = value
-                            ? ''
-                            : 'red';
-                    });
-                component.inputEl.style.borderColor = this.plugin.settings
-                    .geocodingApiKey
-                    ? ''
-                    : 'red';
-            });
+            .addComponent((component) =>
+                new SecretComponent(this.app, component)
+                    .setValue(this.plugin.settings.geocodingApiKeySecret)
+                    .onChange((value) => {
+                        this.plugin.settings.geocodingApiKeySecret = value;
+                        this.plugin.saveSettings();
+                        component.style.borderColor = value ? '' : 'red';
+                    }),
+            );
         let googlePlacesControl = new Setting(containerEl)
             .setName('Use Google Places for searches')
             .setDesc(
@@ -818,19 +816,24 @@ export class SettingsTab extends PluginSettingTab {
                         this.plugin.saveSettings();
                     });
             });
+
         new Setting(containerEl)
             .setName('GraphHopper API key')
             .setDesc(
                 'You may obtain a free or a paid key from GraphHopper to enable native routing in Map View.',
             )
-            .addText((component) => {
-                component
-                    .setValue(this.plugin.settings.routingGraphHopperApiKey)
-                    .onChange(async (value: string) => {
-                        this.plugin.settings.routingGraphHopperApiKey = value;
+            .addComponent((component) =>
+                new SecretComponent(this.app, component)
+                    .setValue(
+                        this.plugin.settings.routingGraphHopperApiKeySecret,
+                    )
+                    .onChange((value) => {
+                        this.plugin.settings.routingGraphHopperApiKeySecret =
+                            value;
                         this.plugin.saveSettings();
-                    });
-            });
+                    }),
+            );
+
         new Setting(containerEl)
             .setName('GraphHopper profiles')
             .setDesc(

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -25,8 +25,6 @@ import { DEFAULT_MAX_TILE_ZOOM, MAX_ZOOM } from 'src/consts';
 import { openManagerDialog } from 'src/offlineTiles.svelte';
 import { SvelteModal } from 'src/svelte';
 import DisplayRules from './components/DisplayRules.svelte';
-import { value } from 'happy-dom/lib/PropertySymbol';
-import { V } from 'vitest/dist/chunks/reporters.d.DVUYHHhe';
 
 export class SettingsTab extends PluginSettingTab {
     plugin: MapViewPlugin;

--- a/src/urlConvertor.ts
+++ b/src/urlConvertor.ts
@@ -126,6 +126,7 @@ export class UrlConvertor {
     async getGeolocationFromGoogleLink(
         url: string,
         settings: PluginSettings,
+        app: App,
     ): Promise<leaflet.LatLng> {
         const content = await request({ url: url });
         if (this.settings.debug) console.log('Google link: searching url', url);
@@ -136,7 +137,9 @@ export class UrlConvertor {
             const placeName = placeNameMatch[1];
             if (this.settings.debug)
                 console.log('Google link: found place name = ', placeName);
-            const googleApiKey = settings.geocodingApiKey;
+            const googleApiKey = app.secretStorage.getSecret(
+                settings.geocodingApiKeySecret,
+            );
             const params = {
                 query: placeName,
                 key: googleApiKey,

--- a/src/viewControls.ts
+++ b/src/viewControls.ts
@@ -604,6 +604,7 @@ export class RoutingControl extends leaflet.Control {
                             marker.location,
                             menu,
                             this.settings,
+                            this.app,
                         );
                         menu.showAtMouseEvent(ev);
                     }


### PR DESCRIPTION
# Background
Currently, the API keys are just stored in the app settings. This isn't recommended anymore,
# Changes
 - migrated all legacy keys to the new system
 - all places where keys got retrieved now use `secretStorage`
# Testing
Validated locally end-to-end
# Disclosure
No LLM's were used to write any code as part of this ticket.