### PR TITLE
docs: add a Map View vs. Advanced Maps comparison page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -82,6 +82,10 @@ export default defineConfig({
                         link: '/vs-obsidian-maps',
                     },
                     {
+                        text: 'vs. Advanced Maps',
+                        link: '/vs-advanced-maps',
+                    },
+                    {
                         text: 'vs. Obsidian Leaflet',
                         link: '/vs-leaflet',
                     },

--- a/docs/vs-advanced-maps.md
+++ b/docs/vs-advanced-maps.md
@@ -1,0 +1,33 @@
+# Map View vs. Advanced Maps
+
+[Advanced Maps](https://jin1c-3.github.io/obsidian-advanced-maps/en/) differs from the other plugins compared here in one structural way: it has no map view of its own. It extends the first-party Obsidian Maps view rather than rendering its own map, and bundles no map library. [Map View vs. Obsidian Maps](vs-obsidian-maps.md) is worth reading first, because several rows marked unsupported there change when Advanced Maps is installed.
+
+## What's Similar
+
+- Both display notes as pins on an interactive map, and respond to Bases filters.
+- Both draw GPX, KML, TCX and GeoJSON paths, from stand-alone files or from notes that link to them.
+- Both can search for places, enter a geolocation from the map, use the device's GPS, and show a map with no network connection.
+- Both draw an elevation profile for a path that carries elevation data.
+
+## What's Different
+
+|                        | Map View                                                     | Obsidian Maps + Advanced Maps                                                                           |
+| ---------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| **Work mode**          | Bases or a stand-alone view                                  | Bases, plus inline maps from an embedded track file                                                     |
+| **Locations per note** | Many — front matter + unlimited inline locations             | One, front matter only                                                                                  |
+| **Inline locations**   | Supported, with per-location inline tags                     | Not supported                                                                                           |
+| **Marker styling**     | Query-based display rules with icons, colors, shapes, badges | Bases properties and formulas, which the plugin leaves untouched                                        |
+| **Filtering**          | Bases filter + Map View's own query language                 | Bases filter                                                                                            |
+| **Routing**            | Built-in via GraphHopper API                                 | Not supported                                                                                           |
+| **Path statistics**    | Elevation profile in the marker popup                        | Elevation profile, plus distance and elevation figures written into note properties that Bases can sort |
+| **Geotagged photos**   | Not supported                                                | Placed on the map by their own EXIF, as thumbnails                                                      |
+| **Offline usage**      | Automatic cache + batch download                             | A folder of tiles already on disk; no bulk download                                                     |
+| **Map sources**        | Tile based                                                   | Vector or tile based                                                                                    |
+| **Basemap alignment**  | Any tile source, with no datum conversion                    | GCJ-02 and BD-09 basemaps aligned with WGS-84 note coordinates                                          |
+
+## Which Should I Use?
+
+- **Map View** is the better choice if you want several locations in one note, inline geolocations in body text, display rules, built-in routing, or a map that does not require Bases at all.
+- **Advanced Maps** may be the better choice if your notes already live in Bases, and you want the built-in Maps view to also show paths with sortable statistics, whole folders of geotagged photos, and locations entered from a search, a pasted map link or the map itself. It is also the one that aligns a Chinese basemap with WGS-84 coordinates.
+
+The two are not mutually exclusive, and they do not read the same data: inline geolocations are invisible to Bases, so a vault that uses them keeps needing Map View either way.

--- a/docs/vs-obsidian-maps.md
+++ b/docs/vs-obsidian-maps.md
@@ -35,6 +35,8 @@ Here is a more in-depth comparison:
 | **Offline usage**              | Not supported                            | Automatic cache + batch download for offline use                                          |
 | **Map sources**                | Vector or tile based                     | Tile based                                                                                |
 
+Some of the rows above change if you extend Obsidian Maps with a community plugin — see [Map View vs. Advanced Maps](vs-advanced-maps.md).
+
 ## Location Format
 
 While Maps does not support all the location formats that Map View does, and most importantly not inline locations, the basic front matter format can work on both:

--- a/docs/vs-obsidian-maps.md
+++ b/docs/vs-obsidian-maps.md
@@ -35,7 +35,7 @@ Here is a more in-depth comparison:
 | **Offline usage**              | Not supported                            | Automatic cache + batch download for offline use                                          |
 | **Map sources**                | Vector or tile based                     | Tile based                                                                                |
 
-Some of the rows above change if you extend Obsidian Maps with a community plugin — see [Map View vs. Advanced Maps](vs-advanced-maps.md).
+Some of the rows above change if you extend Obsidian Maps with a community plugin -- see [Map View vs. Advanced Maps](vs-advanced-maps.md).
 
 ## Location Format
 


### PR DESCRIPTION
Following up on #412, where you pointed at this doc instead of per-issue comments — thanks again for that.

## What this adds

- `docs/vs-advanced-maps.md`, in the same shape as `vs-leaflet.md`: intro, What's Similar, What's Different, Which Should I Use?
- One sidebar entry under **Reference**.
- One line under the table in `vs-obsidian-maps.md` pointing at the new page. That table's "Obsidian Maps" column marks paths, geocoding, entering locations, GPS and offline usage as unsupported. That is accurate for the view on its own, and it stops being the whole story once a reader extends it.

## What I deliberately did not do

- Nothing about Map View is reworded. No existing row is edited, and no claim about your plugin is touched.
- No third column in `vs-obsidian-maps.md`. That page is your comparison; a new page seemed like the version that leaves it alone.
- The right-hand column is headed **Obsidian Maps + Advanced Maps**, not just Advanced Maps. It has no map view of its own, so the vector maps, markers and Bases formulas in that column are the first-party view's work, not mine.
- Every claim in the Map View column is checked against this repository rather than assumed. Two rows say "not supported" — geotagged photos and GCJ-02/BD-09 alignment — and I wrote them only after finding no `exif`, `photo`, `geotag`, `gcj`, `bd09`, `baidu` or `amap` anywhere in `src/`. Elevation started out in my column until I found `createElevationGraph()` in `MarkerPopup.svelte`; it is now listed under What's Similar, and only the writing of figures into sortable note properties is left as a difference. If I still got a cell wrong, it is a mistake and not a position — say so and I will fix it.

The table runs about six rows to five in your favour, which is roughly how it is: these are differently shaped plugins rather than competing ones, and they mostly do not want the same vaults. Inline geolocations are invisible to Bases, so a vault built on them needs Map View regardless of what I ship.

`npm run stylecheck` and `npm run docs:build` both pass.

It is your doc — reword it, cut it down to one line, or close this. No hard feelings in any of those directions.
